### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Log/Logger.php
+++ b/lib/Horde/Log/Logger.php
@@ -85,6 +85,15 @@ class Horde_Log_Logger implements Serializable
         ));
     }
 
+    public function __serialize()
+    {
+        return array(
+            self::VERSION,
+            $this->_filters,
+            $this->_handlers
+	);
+    }
+
     /**
      * Unserialize.
      *
@@ -95,6 +104,20 @@ class Horde_Log_Logger implements Serializable
     public function unserialize($data)
     {
         $data = @unserialize($data);
+        if (!is_array($data) ||
+            !isset($data[0]) ||
+            ($data[0] != self::VERSION)) {
+            throw new Exception('Cache version change');
+        }
+
+        $this->_filters = $data[1];
+        $this->_handlers = $data[2];
+
+        $this->_init();
+    }
+
+    public function __unserialize($data)
+    {
         if (!is_array($data) ||
             !isset($data[0]) ||
             ($data[0] != self::VERSION)) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Log/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Log/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Log Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Log/Filter/ChainingTest.php
+++ b/test/Horde/Log/Filter/ChainingTest.php
@@ -22,6 +22,7 @@
  * @package    Log
  * @subpackage UnitTests
  */
+#[\AllowDynamicProperties]
 class Horde_Log_Filter_ChainingTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/Log/Filter/ChainingTest.php
+++ b/test/Horde/Log/Filter/ChainingTest.php
@@ -22,9 +22,9 @@
  * @package    Log
  * @subpackage UnitTests
  */
-class Horde_Log_Filter_ChainingTest extends PHPUnit_Framework_TestCase
+class Horde_Log_Filter_ChainingTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         date_default_timezone_set('America/New_York');
 
@@ -33,7 +33,7 @@ class Horde_Log_Filter_ChainingTest extends PHPUnit_Framework_TestCase
         $this->logger->addHandler(new Horde_Log_Handler_Stream($this->log));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         fclose($this->log);
     }
@@ -49,8 +49,8 @@ class Horde_Log_Filter_ChainingTest extends PHPUnit_Framework_TestCase
         rewind($this->log);
         $logdata = stream_get_contents($this->log);
 
-        $this->assertNotContains($ignored, $logdata);
-        $this->assertContains($logged, $logdata);
+        $this->assertStringNotContainsString($ignored, $logdata);
+        $this->assertStringContainsString($logged, $logdata);
     }
 
 
@@ -67,13 +67,13 @@ class Horde_Log_Filter_ChainingTest extends PHPUnit_Framework_TestCase
 
         rewind($this->log);
         $logdata = stream_get_contents($this->log);
-        $this->assertContains($warn, $logdata);
-        $this->assertContains($err, $logdata);
+        $this->assertStringContainsString($warn, $logdata);
+        $this->assertStringContainsString($err, $logdata);
 
         rewind($log2);
         $logdata = stream_get_contents($log2);
-        $this->assertContains($err, $logdata);
-        $this->assertNotContains($warn, $logdata);
+        $this->assertStringContainsString($err, $logdata);
+        $this->assertStringNotContainsString($warn, $logdata);
     }
 
 }

--- a/test/Horde/Log/Filter/ConstraintTest.php
+++ b/test/Horde/Log/Filter/ConstraintTest.php
@@ -67,7 +67,9 @@ class Horde_Log_Filter_ConstraintTest extends Horde_Test_Case
 
     private function getConstraintMock($returnVal)
     {
-        $const = $this->getMock('Horde_Constraint', array('evaluate'));
+        $const = $this->getMockBuilder('Horde_Constraint')
+                      ->setMethods(array('evaluate'))
+                      ->getMock();
         $const->expects($this->once())
             ->method('evaluate')
             ->will($this->returnValue($returnVal));
@@ -90,7 +92,9 @@ class Horde_Log_Filter_ConstraintTest extends Horde_Test_Case
         $filterator->addConstraint('fieldname', $this->getConstraintMock(true));
         $filterator->addConstraint('fieldname', new Horde_Constraint_AlwaysFalse());
 
-        $const = $this->getMock('Horde_Constraint', array('evaluate'));
+        $const = $this->getMockBuilder('Horde_Constraint')
+                      ->setMethods(array('evaluate'))
+                      ->getMock();
         $const->expects($this->never())
             ->method('evaluate');
         $filterator->addConstraint('fieldname', $const);
@@ -101,7 +105,9 @@ class Horde_Log_Filter_ConstraintTest extends Horde_Test_Case
     public function testFilterAcceptCallsConstraintOnNullWhenFieldDoesnotExist()
     {
         $filterator = new Horde_Log_Filter_Constraint();
-        $const = $this->getMock('Horde_Constraint', array('evaluate'));
+        $const = $this->getMockBuilder('Horde_Constraint')
+                      ->setMethods(array('evaluate'))
+                      ->getMock();
         $const->expects($this->once())
             ->method('evaluate')
             ->with(null);

--- a/test/Horde/Log/Filter/ExactLevelTest.php
+++ b/test/Horde/Log/Filter/ExactLevelTest.php
@@ -22,9 +22,9 @@
  * @package    Log
  * @subpackage UnitTests
  */
-class Horde_Log_Filter_ExactLevelTest extends PHPUnit_Framework_TestCase
+class Horde_Log_Filter_ExactLevelTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         // accept at and only at level 2
         $this->filter = new Horde_Log_Filter_ExactLevel(2);

--- a/test/Horde/Log/Filter/ExactLevelTest.php
+++ b/test/Horde/Log/Filter/ExactLevelTest.php
@@ -48,7 +48,7 @@ class Horde_Log_Filter_ExactLevelTest extends Horde_Test_Case
             $this->fail();
         } catch (Exception $e) {
             $this->assertInstanceOf('InvalidArgumentException', $e);
-            $this->assertRegExp('/must be an integer/i', $e->getMessage());
+            $this->assertMatchesRegularExpression('/must be an integer/i', $e->getMessage());
         }
     }
 }

--- a/test/Horde/Log/Filter/ExactLevelTest.php
+++ b/test/Horde/Log/Filter/ExactLevelTest.php
@@ -22,6 +22,7 @@
  * @package    Log
  * @subpackage UnitTests
  */
+#[\AllowDynamicProperties]
 class Horde_Log_Filter_ExactLevelTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/Log/Filter/LevelTest.php
+++ b/test/Horde/Log/Filter/LevelTest.php
@@ -22,9 +22,9 @@
  * @package    Log
  * @subpackage UnitTests
  */
-class Horde_Log_Filter_LevelTest extends PHPUnit_Framework_TestCase
+class Horde_Log_Filter_LevelTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         // accept at or below level 2
         $this->filter = new Horde_Log_Filter_Level(2);

--- a/test/Horde/Log/Filter/LevelTest.php
+++ b/test/Horde/Log/Filter/LevelTest.php
@@ -48,7 +48,7 @@ class Horde_Log_Filter_LevelTest extends Horde_Test_Case
             $this->fail();
         } catch (Exception $e) {
             $this->assertInstanceOf('InvalidArgumentException', $e);
-            $this->assertRegExp('/must be an integer/i', $e->getMessage());
+            $this->assertMatchesRegularExpression('/must be an integer/i', $e->getMessage());
         }
     }
 }

--- a/test/Horde/Log/Filter/LevelTest.php
+++ b/test/Horde/Log/Filter/LevelTest.php
@@ -22,6 +22,7 @@
  * @package    Log
  * @subpackage UnitTests
  */
+#[\AllowDynamicProperties]
 class Horde_Log_Filter_LevelTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/Log/Filter/MessageTest.php
+++ b/test/Horde/Log/Filter/MessageTest.php
@@ -22,7 +22,7 @@
  * @package    Log
  * @subpackage UnitTests
  */
-class Horde_Log_Filter_MessageTest extends PHPUnit_Framework_TestCase
+class Horde_Log_Filter_MessageTest extends Horde_Test_Case
 {
 
     public function testMessageFilterRecognizesInvalidRegularExpression()

--- a/test/Horde/Log/Filter/MessageTest.php
+++ b/test/Horde/Log/Filter/MessageTest.php
@@ -31,7 +31,7 @@ class Horde_Log_Filter_MessageTest extends Horde_Test_Case
             $filter = new Horde_Log_Filter_Message('invalid regexp');
             $this->fail();
         } catch (InvalidArgumentException $e) {
-            $this->assertRegexp('/invalid reg/i', $e->getMessage());
+            $this->assertMatchesRegularExpression('/invalid reg/i', $e->getMessage());
         }
     }
 

--- a/test/Horde/Log/Filter/SuppressTest.php
+++ b/test/Horde/Log/Filter/SuppressTest.php
@@ -22,9 +22,9 @@
  * @package    Log
  * @subpackage UnitTests
  */
-class Horde_Log_Filter_SuppressTest extends PHPUnit_Framework_TestCase
+class Horde_Log_Filter_SuppressTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->filter = new Horde_Log_Filter_Suppress();
     }

--- a/test/Horde/Log/Filter/SuppressTest.php
+++ b/test/Horde/Log/Filter/SuppressTest.php
@@ -22,6 +22,7 @@
  * @package    Log
  * @subpackage UnitTests
  */
+#[\AllowDynamicProperties]
 class Horde_Log_Filter_SuppressTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/Log/Formatter/SimpleTest.php
+++ b/test/Horde/Log/Formatter/SimpleTest.php
@@ -31,7 +31,7 @@ class Horde_Log_Formatter_SimpleTest extends Horde_Test_Case
             $this->fail();
         } catch (Exception $e) {
             $this->assertInstanceOf('InvalidArgumentException', $e);
-            $this->assertRegExp('/must be a string/i', $e->getMessage());
+            $this->assertMatchesRegularExpression('/must be a string/i', $e->getMessage());
         }
     }
 

--- a/test/Horde/Log/Formatter/SimpleTest.php
+++ b/test/Horde/Log/Formatter/SimpleTest.php
@@ -22,7 +22,7 @@
  * @package    Log
  * @subpackage UnitTests
  */
-class Horde_Log_Formatter_SimpleTest extends PHPUnit_Framework_TestCase
+class Horde_Log_Formatter_SimpleTest extends Horde_Test_Case
 {
     public function testConstructorThrowsOnBadFormatString()
     {
@@ -42,7 +42,7 @@ class Horde_Log_Formatter_SimpleTest extends PHPUnit_Framework_TestCase
                                  'level' => $level = Horde_Log::ALERT,
                                  'levelName' => $levelName = 'ALERT'));
 
-        $this->assertContains($message, $line);
-        $this->assertContains($levelName, $line);
+        $this->assertStringContainsString($message, $line);
+        $this->assertStringContainsString($levelName, $line);
     }
 }

--- a/test/Horde/Log/Formatter/XmlTest.php
+++ b/test/Horde/Log/Formatter/XmlTest.php
@@ -20,9 +20,9 @@
  * @license  http://www.horde.org/licenses/bsd BSD
  * @package  Log
  */
-class Horde_Log_Formatter_XmlTest extends PHPUnit_Framework_TestCase
+class Horde_Log_Formatter_XmlTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         date_default_timezone_set('America/New_York');
     }
@@ -32,8 +32,8 @@ class Horde_Log_Formatter_XmlTest extends PHPUnit_Framework_TestCase
         $f = new Horde_Log_Formatter_Xml();
         $line = $f->format(array('message' => $message = 'message', 'level' => $level = 1));
 
-        $this->assertContains($message, $line);
-        $this->assertContains((string)$level, $line);
+        $this->assertStringContainsString($message, $line);
+        $this->assertStringContainsString((string)$level, $line);
     }
 
     public function testXmlDeclarationIsStripped()
@@ -41,7 +41,7 @@ class Horde_Log_Formatter_XmlTest extends PHPUnit_Framework_TestCase
         $f = new Horde_Log_Formatter_Xml();
         $line = $f->format(array('message' => $message = 'message', 'level' => $level = 1));
 
-        $this->assertNotContains('<\?xml version=', $line);
+        $this->assertStringNotContainsString('<\?xml version=', $line);
     }
 
     public function testXmlValidates()

--- a/test/Horde/Log/Handler/FirebugTest.php
+++ b/test/Horde/Log/Handler/FirebugTest.php
@@ -37,7 +37,7 @@ class Horde_Log_Handler_FirebugTest extends Horde_Test_Case
             $this->fail();
         } catch (Exception $e) {
             $this->assertInstanceOf('Horde_Log_Exception', $e);
-            $this->assertRegExp('/unknown option/i', $e->getMessage());
+            $this->assertMatchesRegularExpression('/unknown option/i', $e->getMessage());
         }
     }
 
@@ -55,7 +55,7 @@ class Horde_Log_Handler_FirebugTest extends Horde_Test_Case
 
         $date = '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2}';
 
-        $this->assertRegExp("/console.error\(\"$date $levelName: $message\"\);/", $contents);
+        $this->assertMatchesRegularExpression("/console.error\(\"$date $levelName: $message\"\);/", $contents);
     }
 
 }

--- a/test/Horde/Log/Handler/FirebugTest.php
+++ b/test/Horde/Log/Handler/FirebugTest.php
@@ -22,9 +22,9 @@
  * @package    Log
  * @subpackage UnitTests
  */
-class Horde_Log_Handler_FirebugTest extends PHPUnit_Framework_TestCase
+class Horde_Log_Handler_FirebugTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         date_default_timezone_set('America/New_York');
     }

--- a/test/Horde/Log/Handler/NullTest.php
+++ b/test/Horde/Log/Handler/NullTest.php
@@ -22,7 +22,7 @@
  * @package    Log
  * @subpackage UnitTests
  */
-class Horde_Log_Handler_NullTest extends PHPUnit_Framework_TestCase
+class Horde_Log_Handler_NullTest extends Horde_Test_Case
 {
     public function testWrite()
     {

--- a/test/Horde/Log/Handler/StreamTest.php
+++ b/test/Horde/Log/Handler/StreamTest.php
@@ -37,7 +37,7 @@ class Horde_Log_Handler_StreamTest extends Horde_Test_Case
             $this->fail();
         } catch (Exception $e) {
             $this->assertInstanceOf('Horde_Log_Exception', $e);
-            $this->assertRegExp('/not a stream/i', $e->getMessage());
+            $this->assertMatchesRegularExpression('/not a stream/i', $e->getMessage());
         }
         xml_parser_free($resource);
     }
@@ -63,7 +63,7 @@ class Horde_Log_Handler_StreamTest extends Horde_Test_Case
             $this->fail();
         } catch (Exception $e) {
             $this->assertInstanceOf('Horde_Log_Exception', $e);
-            $this->assertRegExp('/existing stream/i', $e->getMessage());
+            $this->assertMatchesRegularExpression('/existing stream/i', $e->getMessage());
         }
     }
 
@@ -74,7 +74,7 @@ class Horde_Log_Handler_StreamTest extends Horde_Test_Case
             $this->fail();
         } catch (Exception $e) {
             $this->assertInstanceOf('Horde_Log_Exception', $e);
-            $this->assertRegExp('/cannot be opened/i', $e->getMessage());
+            $this->assertMatchesRegularExpression('/cannot be opened/i', $e->getMessage());
         }
     }
 
@@ -86,7 +86,7 @@ class Horde_Log_Handler_StreamTest extends Horde_Test_Case
             $this->fail();
         } catch (Exception $e) {
             $this->assertInstanceOf('Horde_Log_Exception', $e);
-            $this->assertRegExp('/unknown option/i', $e->getMessage());
+            $this->assertMatchesRegularExpression('/unknown option/i', $e->getMessage());
         }
     }
 
@@ -106,7 +106,7 @@ class Horde_Log_Handler_StreamTest extends Horde_Test_Case
 
         $date = '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2}';
 
-        $this->assertRegExp("/$date $levelName: $message/", $contents);
+        $this->assertMatchesRegularExpression("/$date $levelName: $message/", $contents);
     }
 
     public function testWriteThrowsWhenStreamWriteFails()
@@ -120,7 +120,7 @@ class Horde_Log_Handler_StreamTest extends Horde_Test_Case
             $this->fail();
         } catch (Exception $e) {
             $this->assertInstanceOf('Horde_Log_Exception', $e);
-            $this->assertRegExp('/unable to write/i', $e->getMessage());
+            $this->assertMatchesRegularExpression('/unable to write/i', $e->getMessage());
         }
     }
 

--- a/test/Horde/Log/Handler/StreamTest.php
+++ b/test/Horde/Log/Handler/StreamTest.php
@@ -22,9 +22,9 @@
  * @package    Log
  * @subpackage UnitTests
  */
-class Horde_Log_Handler_StreamTest extends PHPUnit_Framework_TestCase
+class Horde_Log_Handler_StreamTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         date_default_timezone_set('America/New_York');
     }
@@ -44,12 +44,14 @@ class Horde_Log_Handler_StreamTest extends PHPUnit_Framework_TestCase
 
     public function testConstructorWithValidStream()
     {
+        $this->expectNotToPerformAssertions();
         $stream = fopen('php://memory', 'a');
         new Horde_Log_Handler_Stream($stream);
     }
 
     public function testConstructorWithValidUrl()
     {
+        $this->expectNotToPerformAssertions();
         new Horde_Log_Handler_Stream('php://memory');
     }
 

--- a/test/Horde/Log/LogTest.php
+++ b/test/Horde/Log/LogTest.php
@@ -22,9 +22,9 @@
  * @package    Log
  * @subpackage UnitTests
  */
-class Horde_Log_LogTest extends PHPUnit_Framework_TestCase
+class Horde_Log_LogTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         date_default_timezone_set('America/New_York');
 
@@ -40,7 +40,7 @@ class Horde_Log_LogTest extends PHPUnit_Framework_TestCase
         $logger->log($message = 'message-to-long', Horde_Log::INFO);
 
         rewind($this->log);
-        $this->assertContains($message, stream_get_contents($this->log));
+        $this->assertStringContainsString($message, stream_get_contents($this->log));
     }
 
     public function testaddHandler()
@@ -50,7 +50,7 @@ class Horde_Log_LogTest extends PHPUnit_Framework_TestCase
         $logger->log($message = 'message-to-log', Horde_Log::INFO);
 
         rewind($this->log);
-        $this->assertContains($message, stream_get_contents($this->log));
+        $this->assertStringContainsString($message, stream_get_contents($this->log));
     }
 
     public function testaddHandlerAddsMultipleHandlers()
@@ -72,9 +72,9 @@ class Horde_Log_LogTest extends PHPUnit_Framework_TestCase
 
         // verify both handlers were called by the logger
         rewind($log1);
-        $this->assertContains($message, stream_get_contents($log1));
+        $this->assertStringContainsString($message, stream_get_contents($log1));
         rewind($log2);
-        $this->assertContains($message, stream_get_contents($log2));
+        $this->assertStringContainsString($message, stream_get_contents($log2));
 
         // prove the two memory streams are different
         // and both handlers were indeed called
@@ -141,7 +141,7 @@ class Horde_Log_LogTest extends PHPUnit_Framework_TestCase
 
         rewind($this->log);
         $logdata = stream_get_contents($this->log);
-        $this->assertContains($levelName, $logdata);
-        $this->assertContains($message, $logdata);
+        $this->assertStringContainsString($levelName, $logdata);
+        $this->assertStringContainsString($message, $logdata);
     }
 }

--- a/test/Horde/Log/LogTest.php
+++ b/test/Horde/Log/LogTest.php
@@ -22,6 +22,7 @@
  * @package    Log
  * @subpackage UnitTests
  */
+#[\AllowDynamicProperties]
 class Horde_Log_LogTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/Log/LogTest.php
+++ b/test/Horde/Log/LogTest.php
@@ -89,7 +89,7 @@ class Horde_Log_LogTest extends Horde_Test_Case
             $logger->log('message', Horde_Log::INFO);
             $this->fail();
         } catch (Horde_Log_Exception $e) {
-            $this->assertRegexp('/no handler/i', $e->getMessage());
+            $this->assertMatchesRegularExpression('/no handler/i', $e->getMessage());
         }
     }
 
@@ -103,7 +103,7 @@ class Horde_Log_LogTest extends Horde_Test_Case
             $this->fail();
         } catch (Exception $e) {
             $this->assertInstanceOf('Horde_Log_Exception', $e);
-            $this->assertRegExp('/bad log level/i', $e->getMessage());
+            $this->assertMatchesRegularExpression('/bad log level/i', $e->getMessage());
         }
     }
 
@@ -115,7 +115,7 @@ class Horde_Log_LogTest extends Horde_Test_Case
             $this->fail();
         } catch (Exception $e) {
             $this->assertInstanceOf('Horde_Log_Exception', $e);
-            $this->assertRegExp('/bad log level/i', $e->getMessage());
+            $this->assertMatchesRegularExpression('/bad log level/i', $e->getMessage());
         }
     }
 
@@ -127,7 +127,7 @@ class Horde_Log_LogTest extends Horde_Test_Case
             $this->fail();
         } catch (Exception $e) {
             $this->assertInstanceOf('Horde_Log_Exception', $e);
-            $this->assertRegExp('/existing log level/i', $e->getMessage());
+            $this->assertMatchesRegularExpression('/existing log level/i', $e->getMessage());
         }
 
     }


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-log/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Add 1011_php8.1.patch. https://salsa.debian.org/horde-team/php-horde-log/-/blob/debian-sid/debian/patches/1011_php8.1.patch
- Debian changes: Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-log/-/blob/debian-sid/debian/patches/1012_php8.2.patch
